### PR TITLE
修复@逻辑

### DIFF
--- a/itchat/client.py
+++ b/itchat/client.py
@@ -424,8 +424,7 @@ class client(object):
         msg['ActualNickName'] = member['NickName']
         msg['Content']        = content
         tools.msg_formatter(msg, 'Content')
-        msg['isAt']           = u'@%s\u2005' % (member['DisplayName'] or 
-            self.storageClass.nickName) in msg['Content']
+        msg['isAt']           = u'@%s\u2005' %  self.storageClass.nickName in msg['Content']
     def send_msg(self, msg = 'Test Message', toUserName = None):
         url = '%s/webwxsendmsg'%self.loginInfo['url']
         payloads = {


### PR DESCRIPTION
member['DisplayName'] or self.storageClass.nickName
menber我没看错的话应该是发送方的相关数据，一旦发送方在群里设置了昵称，这个member['DisplayName'] 就是发送方的昵称，导致isAt永远为False。