### PR TITLE
添加 enableCmdQR 参数以解决登录异常

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ A: 有两种方式：发送、接受自己UserName的消息；发送接收文件
 
 或者也可以在gitter上交流：[![Gitter][gitter-picture]][gitter]
 
+当然也可以加入我们新建的QQ群讨论：549762872
+
 [gitter-picture]: https://badges.gitter.im/littlecodersh/ItChat.svg
 [gitter]: https://gitter.im/littlecodersh/ItChat?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
 [py27]: https://img.shields.io/badge/python-2.7-ff69b4.svg

--- a/itchat/__init__.py
+++ b/itchat/__init__.py
@@ -3,7 +3,7 @@ import time
 from .client import client
 from . import content # this is for creating pyc
 
-__version__ = '1.1.11'
+__version__ = '1.1.12'
 
 __client = client()
 def auto_login(hotReload=False, statusStorageDir='itchat.pkl', enableCmdQR=False):

--- a/itchat/client.py
+++ b/itchat/client.py
@@ -336,7 +336,12 @@ class client(object):
                 if m['AppMsgType'] == 6:
                     def download_atta(attaDir=None):
                         cookiesList = {name:data for name,data in self.s.cookies.items()}
-                        url = 'https://file%s.wx.qq.com/cgi-bin/mmwebwx-bin/webwxgetmedia'%('2' if '2' in self.loginInfo['url'] else '')
+                        url = '/cgi-bin/mmwebwx-bin/webwxgetmedia'
+                        if 'web.wechat.com' in self.loginInfo['url']:
+                            url = 'https://file.web%s.wechat.com' + url
+                        else:
+                            url = 'https://file%s.wx.qq.com' + url
+                        url = url % ('2' if '2' in self.loginInfo['url'] else '')
                         payloads = {
                             'sender': m['FromUserName'],
                             'mediaid': m['MediaId'],
@@ -446,7 +451,12 @@ class client(object):
         return r.json()['BaseResponse']['Ret'] == 0
     def __upload_file(self, fileDir, isPicture = False, isVideo = False):
         if not tools.check_file(fileDir): return
-        url = 'https://file%s.wx.qq.com/cgi-bin/mmwebwx-bin/webwxuploadmedia?f=json'%('2' if '2' in self.loginInfo['url'] else '')
+        url = '/cgi-bin/mmwebwx-bin/webwxuploadmedia?f=json'
+        if 'web.wechat.com' in self.loginInfo['url']:
+            url = 'https://file.web%s.wechat.com' + url
+        else:
+            url = 'https://file%s.wx.qq.com' + url
+        url = url % ('2' if '2' in self.loginInfo['url'] else '')
         # save it on server
         fileSize = str(os.path.getsize(fileDir))
         cookiesList = {name:data for name,data in self.s.cookies.items()}

--- a/itchat/tools.py
+++ b/itchat/tools.py
@@ -100,7 +100,7 @@ try:
         sys.stdout.write(qr)
 except ImportError:
     def print_cmd_qr(fileDir, size = 37, padding = 3,
-            white = BLOCK, black = '  '):
+            white = BLOCK, black = '  ', enableCmdQR = True):
         print('pillow should be installed to use command line QRCode: pip install pillow')
         print_qr(fileDir)
 def struct_friend_info(knownInfo):


### PR DESCRIPTION
当pillow没有安装时，本来应该使用备用的函数提示用户手动扫码，但由于缺少`enableCmdQR`参数，触发了client.py中的`except`，并出现莫名其妙的报错 “Failed to get QR Code, please restart the program”