### PR TITLE
修复登录即出现LOG OUT问题

### DIFF
--- a/itchat/client.py
+++ b/itchat/client.py
@@ -4,6 +4,8 @@ import threading, subprocess
 import json, xml.dom.minidom, mimetypes
 import copy, pickle
 import traceback
+import random
+import collections
 
 import requests
 
@@ -123,12 +125,13 @@ class client(object):
             self.loginInfo['url'] = re.search(regx, r.text).group(1)
             r = self.s.get(self.loginInfo['url'], allow_redirects=False)
             self.loginInfo['url'] = self.loginInfo['url'][:self.loginInfo['url'].rfind('/')]
-            for indexUrl, detailedUrl in {
-                    "wx2.qq.com": ("file.wx2.qq.com", "webpush.wx2.qq.com"),
-                    "wx8.qq.com": ("file.wx8.qq.com", "webpush.wx8.qq.com"),
-                    "qq.com": ("file.wx.qq.com", "webpush.wx.qq.com"),
-                    "web2.wechat.com": ("file.web2.wechat.com", "webpush.web2.wechat.com"),
-                    "wechat.com": ("file.web.wechat.com", "webpush.web.wechat.com"), }.items():
+            d = collections.OrderedDict()
+            d["wx2.qq.com"] = ("file.wx2.qq.com", "webpush.wx2.qq.com")
+            d["wx8.qq.com"] = ("file.wx8.qq.com", "webpush.wx8.qq.com")
+            d["qq.com"] = ("file.wx.qq.com", "webpush.wx.qq.com")
+            d["web2.wechat.com"] = ("file.web2.wechat.com", "webpush.web2.wechat.com")
+            d["wechat.com"] = ("file.web.wechat.com", "webpush.web.wechat.com")
+            for indexUrl, detailedUrl in d.items():
                 fileUrl, syncUrl = ['https://%s/cgi-bin/mmwebwx-bin' % url for url in detailedUrl]
                 if indexUrl in self.loginInfo['url']:
                     self.loginInfo['fileUrl'], self.loginInfo['syncUrl'] = \
@@ -286,13 +289,13 @@ class client(object):
     def __sync_check(self):
         url = '%s/synccheck' % self.loginInfo.get('syncUrl', self.loginInfo['url'])
         params = {
-            'r'        : int(time.time()),
+            'r'        : int(time.time()*1000),
             'skey'     : self.loginInfo['skey'],
             'sid'      : self.loginInfo['wxsid'],
             'uin'      : self.loginInfo['wxuin'],
-            'deviceid' : self.loginInfo['pass_ticket'],
+            'deviceid' : u'e'+repr(random.random())[2:17],
             'synckey'  : self.loginInfo['synckey'],
-            '_'        : int(time.time()),}
+            '_'        : int(time.time()*1000),}
         r = self.s.get(url, params=params)
         regx = r'window.synccheck={retcode:"(\d+)",selector:"(\d+)"}'
         pm = re.search(regx, r.text)


### PR DESCRIPTION
因为python字典是根据其键的hash来排序的，并不能保证第一次循环的时候迭代出键wx2.qq.com，实际上往往第一次循环出qq.com，造成in判断失误，修改方案有两个，一是提取出域名用==判断，二是用有序的字典。
再者修改了长连接参数，使得其更接近webpy