### PR TITLE
strip atFlag in group chat

### DIFF
--- a/itchat/client.py
+++ b/itchat/client.py
@@ -545,6 +545,9 @@ class client(object):
             in msg['Content']
             or
             msg['Content'].endswith(atFlag))
+        if msg['isAt']:
+            msg['Content'] = msg['Content'].replace(atFlag, '').replace(
+                u'\u2005', '')
     def send_raw_msg(self, msgType, content, toUserName):
         url = '%s/webwxsendmsg'%self.loginInfo['url']
         payloads = {


### PR DESCRIPTION
当在群聊中被@时，将atFlag从msg['Content']中剔除。因为isAt已经确定了是@自己，将Content中这部分剔除，用户用起来更方便。

例如，用户需要将msg['Text']转发给图灵机器人。