### PR TITLE
修复bug: 如果nickName里面有Unicode字符，日志会报错

### DIFF
--- a/itchat/components/login.py
+++ b/itchat/components/login.py
@@ -66,7 +66,7 @@ def login(self, enableCmdQR=False, picDir=None, qrCallback=None,
         utils.clear_screen()
         if os.path.exists(picDir or config.DEFAULT_QR):
             os.remove(picDir or config.DEFAULT_QR)
-        logger.info('Login successfully as %s' % self.storageClass.nickName)
+        logger.info(u'Login successfully as %s' % self.storageClass.nickName)
     self.start_receiving(exitCallback)
 
 def get_QRuuid(self):


### PR DESCRIPTION
如果nickName里面有Unicode字符，会报错，错误消息如下：

```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/logging/__init__.py", line 982, in emit
    stream.write(msg)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 34-37: ordinal not in range(128)
Call stack:
  File "/Users/frankdai/github/my-wechat-bot/main.py", line 679, in <module>
    itchat.auto_login(hotReload=True, enableCmdQR=2)
  File "/usr/local/lib/python3.5/site-packages/itchat/components/register.py", line 30, in auto_login
    loginCallback=loginCallback, exitCallback=exitCallback)
  File "/usr/local/lib/python3.5/site-packages/itchat/components/login.py", line 69, in login
    logger.info(u'Login successfully as %s' % self.storageClass.nickName)
```