### PR TITLE
联系人更新消息中没有DisplayName和Uin字段，设置为空

### DIFF
--- a/itchat/components/login.py
+++ b/itchat/components/login.py
@@ -226,6 +226,9 @@ def start_receiving(self, exitCallback=None, getReceivingFnOnly=False):
                             if '@@' in contact['UserName']:
                                 chatroomList.append(contact)
                             else:
+                                # message don't return DisplayName and Uin, set them empty
+                                contact['DisplayName'] = ''
+                                contact['Uin'] = 0
                                 otherList.append(contact)
                         chatroomMsg = update_local_chatrooms(self, chatroomList)
                         self.msgList.put(chatroomMsg)


### PR DESCRIPTION
联系人更新消息中没有DisplayName和Uin字段，设置为空