### PR TITLE
extend .send_raw_msg() to handle more details

### DIFF
--- a/itchat/components/messages.py
+++ b/itchat/components/messages.py
@@ -256,18 +256,20 @@ def produce_group_chat(core, msg):
     msg['Content']        = content
     utils.msg_formatter(msg, 'Content')
 
-def send_raw_msg(self, msgType, content, toUserName):
-    url = '%s/webwxsendmsg' % self.loginInfo['url']
+def send_raw_msg(self, msgType, content, toUserName, uri=None, msgExt=None):
+    url = self.loginInfo['url'] + (uri or '/webwxsendmsg')
+    msg = {
+        'Type': msgType,
+        'Content': content,
+        'FromUserName': self.storageClass.userName,
+        'ToUserName': (toUserName if toUserName else self.storageClass.userName),
+        'LocalID': int(time.time() * 1e4),
+        'ClientMsgId': int(time.time() * 1e4), }
+    if msgExt:
+        msg.update(msgExt)
     data = {
         'BaseRequest': self.loginInfo['BaseRequest'],
-        'Msg': {
-            'Type': msgType,
-            'Content': content,
-            'FromUserName': self.storageClass.userName,
-            'ToUserName': (toUserName if toUserName else self.storageClass.userName),
-            'LocalID': int(time.time() * 1e4),
-            'ClientMsgId': int(time.time() * 1e4),
-            }, 
+        'Msg': msg,
         'Scene': 0, }
     headers = { 'ContentType': 'application/json; charset=UTF-8', 'User-Agent' : config.USER_AGENT }
     r = self.s.post(url, headers=headers,

--- a/itchat/core.py
+++ b/itchat/core.py
@@ -290,8 +290,14 @@ class Core(object):
             it is defined in components/contact.py
         '''
         raise NotImplementedError()
-    def send_raw_msg(self, msgType, content, toUserName):
+    def send_raw_msg(self, msgType, content, toUserName, uri=None, msgExt=None):
         ''' many messages are sent in a common way
+            for options
+                    - msgType: the raw message type number (int)
+                    - content: the raw message content
+                    - toUserName: 'UserName' key of user dict
+                    - uri: the remaining path appended to the base url, '/webwxsendmsg' as default
+                    - msgExt: a dict to extend the 'Msg' key in the request payload by .update()
             for demo
                 .. code:: python
 

--- a/itchat/storage/templates.py
+++ b/itchat/storage/templates.py
@@ -82,10 +82,11 @@ class AbstractUserDict(dict):
             'Ret': -1006,
             'ErrMsg': '%s can not add member' % \
                 self.__class__.__name__, }, })
-    def send_raw_msg(self, msgType, content):
-        return self.core.send_raw_msg(msgType, content, self.userName)
+    def send_raw_msg(self, msgType, content, uri=None, msgExt=None):
+        return self.core.send_raw_msg(
+            msgType, content, self.userName, uri=None, msgExt=None)
     def send_msg(self, msg='Test Message'):
-        return self.core.send_msg(msgType, content, self.userName)
+        return self.core.send_msg(msg, self.userName)
     def send_file(self, fileDir, mediaId=None):
         return self.core.send_file(fileDir, self.userName, mediaId)
     def send_image(self, fileDir, mediaId=None):
@@ -206,7 +207,7 @@ class ChatroomMember(AbstractUserDict):
         return self.core.get_head_img(self.userName, self.chatroom.userName, picDir=imageDir)
     def delete_member(self, userName):
         return self.core.delete_member_from_chatroom(self.chatroom.userName, self.userName)
-    def send_raw_msg(self, msgType, content):
+    def send_raw_msg(self, msgType, content, uri=None, msgExt=None):
         return ReturnValue({'BaseResponse': {
             'Ret': -1006,
             'ErrMsg': '%s can not send message directly' % \


### PR DESCRIPTION
扩展了 send_raw_msg() 函数，增加两个可选参数:
* uri: 方便修改需要追加的 url path (默认为仍为 '/webwxsendmsg')
* msgExt: 方便扩展请求字典中的 'Msg' 键内容 (使用 .update() 方式)

另外修复了 templates.py 中的 AbstractUserDict.send_msg() (原先的内部调用参数错误)
