### PR TITLE
fix: cmd qrCode not show well in Macos terminal iTerm2

### DIFF
--- a/itchat/components/login.py
+++ b/itchat/components/login.py
@@ -111,7 +111,7 @@ def get_QR(self, uuid=None, enableCmdQR=False, picDir=None, qrCallback=None):
         qrCallback(uuid=uuid, status='0', qrcode=qrStorage.getvalue())
     else:
         if enableCmdQR:
-            utils.print_cmd_qr(qrCode.text(1), enableCmdQR=enableCmdQR)
+            print(qrCode.terminal(quiet_zone=1))
         else:
             with open(picDir, 'wb') as f:
                 f.write(qrStorage.getvalue())


### PR DESCRIPTION
cmd qrCode in MacOS terminal will display a messy matrix. So I change the way to display QRcode.
works fine on iTerm2

- Macos version: 10.12.4
- iTerm2 version: 3.0.14
- Python version: 3.6.1