### PR TITLE
'synccheck' 请求失败时对其进行重试

### DIFF
--- a/itchat/components/login.py
+++ b/itchat/components/login.py
@@ -283,6 +283,7 @@ def sync_check(self):
         '_'        : int(time.time() * 1000),}
     headers = { 'User-Agent' : config.USER_AGENT }
     r = self.s.get(url, params=params, headers=headers, timeout=config.TIMEOUT)
+    r.raise_for_status()
     regx = r'window.synccheck={retcode:"(\d+)",selector:"(\d+)"}'
     pm = re.search(regx, r.text)
     if pm is None or pm.group(1) != '0':


### PR DESCRIPTION
近期在使用 `itchat` 的衍生项目时，收到不少反馈，微信端会频繁被登出。经观察，原因都是之前在 #248 反馈过的 `503` 错误。

观察代码发现，只需要在 `sync_check` 中对异常响应抛出异常，即可在 `start_receiving` 中自动进行重试。

另外相关 issue: #410 