### PR TITLE
Add timeout to login process

### DIFF
--- a/itchat/components/login.py
+++ b/itchat/components/login.py
@@ -31,7 +31,7 @@ def load_login(core):
     core.logout            = logout
 
 def login(self, enableCmdQR=False, picDir=None, qrCallback=None,
-        loginCallback=None, exitCallback=None, timeout=None):
+        loginCallback=None, exitCallback=None, timeout=None, timeoutCallback=None):
     start_time = time.time()
     if self.alive or self.isLogging:
         logger.warning('itchat has already logged in.')
@@ -54,6 +54,8 @@ def login(self, enableCmdQR=False, picDir=None, qrCallback=None,
             now = time.time()
             if timeout and (now - start_time) >= timeout:
                 logger.warning('Login timeout, exit.')
+                if hasattr(timeoutCallback, '__call__'):
+                    timeoutCallback()
                 print('Timeout as user setting.')
                 return
 

--- a/itchat/components/login.py
+++ b/itchat/components/login.py
@@ -51,7 +51,8 @@ def login(self, enableCmdQR=False, picDir=None, qrCallback=None,
             logger.info('Please scan the QR code to log in.')
         isLoggedIn = False
         while not isLoggedIn:
-            now = time.time()
+            if timeout:
+                now = time.time()
             if timeout and (now - start_time) >= timeout:
                 logger.warning('Login timeout, exit.')
                 if hasattr(timeoutCallback, '__call__'):

--- a/itchat/components/login.py
+++ b/itchat/components/login.py
@@ -31,7 +31,8 @@ def load_login(core):
     core.logout            = logout
 
 def login(self, enableCmdQR=False, picDir=None, qrCallback=None,
-        loginCallback=None, exitCallback=None):
+        loginCallback=None, exitCallback=None, timeout=None):
+    start_time = time.time()
     if self.alive or self.isLogging:
         logger.warning('itchat has already logged in.')
         return
@@ -50,6 +51,12 @@ def login(self, enableCmdQR=False, picDir=None, qrCallback=None,
             logger.info('Please scan the QR code to log in.')
         isLoggedIn = False
         while not isLoggedIn:
+            now = time.time()
+            if timeout and (now - start_time) >= timeout:
+                logger.warning('Login timeout, exit.')
+                print('Timeout as user setting.')
+                return
+
             status = self.check_login()
             if hasattr(qrCallback, '__call__'):
                 qrCallback(uuid=self.uuid, status=status, qrcode=qrStorage.getvalue())

--- a/itchat/components/register.py
+++ b/itchat/components/register.py
@@ -18,7 +18,7 @@ def load_register(core):
 
 def auto_login(self, hotReload=False, statusStorageDir='itchat.pkl',
         enableCmdQR=False, picDir=None, qrCallback=None,
-        loginCallback=None, exitCallback=None):
+        loginCallback=None, exitCallback=None, timeout=None):
     if not test_connect():
         logger.info("You can't get access to internet or wechat domain, so exit.")
         sys.exit()
@@ -29,11 +29,11 @@ def auto_login(self, hotReload=False, statusStorageDir='itchat.pkl',
                 loginCallback=loginCallback, exitCallback=exitCallback):
             return
         self.login(enableCmdQR=enableCmdQR, picDir=picDir, qrCallback=qrCallback,
-            loginCallback=loginCallback, exitCallback=exitCallback)
+            loginCallback=loginCallback, exitCallback=exitCallback, timeout=timeout)
         self.dump_login_status(statusStorageDir)
     else:
         self.login(enableCmdQR=enableCmdQR, picDir=picDir, qrCallback=qrCallback,
-            loginCallback=loginCallback, exitCallback=exitCallback)
+            loginCallback=loginCallback, exitCallback=exitCallback, timeout=timeout)
 
 def configured_reply(self):
     ''' determine the type of message and reply if its method is defined

--- a/itchat/components/register.py
+++ b/itchat/components/register.py
@@ -18,7 +18,7 @@ def load_register(core):
 
 def auto_login(self, hotReload=False, statusStorageDir='itchat.pkl',
         enableCmdQR=False, picDir=None, qrCallback=None,
-        loginCallback=None, exitCallback=None, timeout=None):
+        loginCallback=None, exitCallback=None, timeout=None, timeoutCallback=None):
     if not test_connect():
         logger.info("You can't get access to internet or wechat domain, so exit.")
         sys.exit()
@@ -29,11 +29,13 @@ def auto_login(self, hotReload=False, statusStorageDir='itchat.pkl',
                 loginCallback=loginCallback, exitCallback=exitCallback):
             return
         self.login(enableCmdQR=enableCmdQR, picDir=picDir, qrCallback=qrCallback,
-            loginCallback=loginCallback, exitCallback=exitCallback, timeout=timeout)
+            loginCallback=loginCallback, exitCallback=exitCallback, timeout=timeout,
+            timeoutCallback=timeoutCallback)
         self.dump_login_status(statusStorageDir)
     else:
         self.login(enableCmdQR=enableCmdQR, picDir=picDir, qrCallback=qrCallback,
-            loginCallback=loginCallback, exitCallback=exitCallback, timeout=timeout)
+            loginCallback=loginCallback, exitCallback=exitCallback, timeout=timeout,
+            timeoutCallback=timeoutCallback)
 
 def configured_reply(self):
     ''' determine the type of message and reply if its method is defined

--- a/itchat/core.py
+++ b/itchat/core.py
@@ -30,7 +30,8 @@ class Core(object):
         self.useHotReload, self.hotReloadDir = False, 'itchat.pkl'
         self.receivingRetryCount = 5
     def login(self, enableCmdQR=False, picDir=None, qrCallback=None,
-            loginCallback=None, exitCallback=None):
+            loginCallback=None, exitCallback=None, timeout=None,
+            timeoutCallback=None):
         ''' log in like web wechat does
             for log in
                 - a QR code will be downloaded and opened
@@ -45,6 +46,11 @@ class Core(object):
                     - if not set, screen is cleared and qrcode is deleted
                 - exitCallback: callback after logged out
                     - it contains calling of logout
+                - timeout: the login process will forcibly end after dedicated
+                           timeout seconds
+                    - if not set, login process will always wait until user
+                      scan the QRCode to proceed.
+                - timeoutCallback: callback after timeout
             for usage
                 ..code::python
 
@@ -399,7 +405,8 @@ class Core(object):
         raise NotImplementedError()
     def auto_login(self, hotReload=False, statusStorageDir='itchat.pkl',
             enableCmdQR=False, picDir=None, qrCallback=None,
-            loginCallback=None, exitCallback=None):
+            loginCallback=None, exitCallback=None, timeout=None,
+            timeoutCallback=None):
         ''' log in like web wechat does
             for log in
                 - a QR code will be downloaded and opened
@@ -416,6 +423,11 @@ class Core(object):
                 - exitCallback: callback after logged out
                     - it contains calling of logout
                 - qrCallback: method that should accept uuid, status, qrcode
+                - timeout: the login process will forcibly end after dedicated
+                           timeout seconds
+                    - if not set, login process will always wait until user
+                      scan the QRCode to proceed.
+                - timeoutCallback: callback after timeout
             for usage
                 ..code::python
 


### PR DESCRIPTION
The original implementation of Itchat will block forever with query for QRCode from time to time when the user does not scan QRCode after launches of login process. However this does not meet our needs of our project, which spawns many WeChat robots with ItChat on the backend server.

If there are users who don't scan the code to proceed the login process, the login process, which runs asynchronously in our server as a separate thread, will hang and write QRCode data to the session all the time, causing serious resource waste and making the server unable to respond eventually.

Thus, I propose that the login process of Itchat have a timeout option. By default the `login()` and `auto_login()` still waits for users until they scan the code, but when the `timeout` option is specified the login process will break by force after dedicated seconds, releasing the occupied threading resources, as well as preventing ongoing query for QRCode even though the users have already given up logging in.