### PR TITLE
修复刚刚启动 itchat 时获取群信息失败的问题

### DIFF
--- a/itchat/components/messages.py
+++ b/itchat/components/messages.py
@@ -239,7 +239,7 @@ def produce_group_chat(core, msg):
     member = utils.search_dict_list((chatroom or {}).get(
         'MemberList') or [], 'UserName', actualUserName)
     if member is None:
-        chatroom = core.update_chatroom(msg['FromUserName'])
+        chatroom = core.update_chatroom(chatroomUserName)
         member = utils.search_dict_list((chatroom or {}).get(
             'MemberList') or [], 'UserName', actualUserName)
     if member is None:


### PR DESCRIPTION
出问题的场景：群内无人发言，仅用户本人发言时获取群信息失败。
问题原因：这种场景下，update_chatroom 使用了错误的群 id。

联系我：微信 hustos