### PR TITLE
Save QR.png anyway

### DIFF
--- a/itchat/components/login.py
+++ b/itchat/components/login.py
@@ -115,11 +115,11 @@ def get_QR(self, uuid=None, enableCmdQR=False, picDir=None, qrCallback=None):
     if hasattr(qrCallback, '__call__'):
         qrCallback(uuid=uuid, status='0', qrcode=qrStorage.getvalue())
     else:
+        with open(picDir, 'wb') as f:
+            f.write(qrStorage.getvalue())
         if enableCmdQR:
             utils.print_cmd_qr(qrCode.text(1), enableCmdQR=enableCmdQR)
         else:
-            with open(picDir, 'wb') as f:
-                f.write(qrStorage.getvalue())
             utils.print_qr(picDir)
     return qrStorage
 


### PR DESCRIPTION
- **修改**
发现在获取二维码的时候，如果`enableCmdQR=True`，也就是直接从终端打印出来的话，不会把二维码保存到本地。我修改了下不管是不是在终端打印，都先写到`picDir`
- **场景**
需要接入机器人的时候，可以随时接入
- **原因**
修改前：首先在服务器上跑的时候，调用GUI不太方便，如果是用`enableCmdQR`形式，需要每次都连上服务器去扫。
修改后：可以把`picDir`写到某个web服务的静态文件里，通过web可以直接访问扫码了。

或者我这种场景有更好的解决办法？祝好。
