### PR TITLE
fix breakage on python 3.9

### DIFF
--- a/itchat/utils.py
+++ b/itchat/utils.py
@@ -18,6 +18,9 @@ logger = logging.getLogger('itchat')
 
 emojiRegex = re.compile(r'<span class="emoji emoji(.{1,10})"></span>')
 htmlParser = HTMLParser()
+if not hasattr(htmlParser, 'unescape'):
+    import html
+    htmlParser.unescape = html.unescape
 try:
     b = u'\u2588'
     sys.stdout.write(b + '\r')


### PR DESCRIPTION
This commit fixes "AttributeError: 'HTMLParser' object has no attribute 'unescape'"
